### PR TITLE
elixir 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Pipes.Mixfile do
   def project do
     [ app: :pipe,
       version: "0.0.1",
-      elixir: "~> 0.13",
+      elixir: "~> 1.0",
       deps: deps,
       package: package,
       description: description ]


### PR DESCRIPTION
This project is referenced from the Elixir Getting Started guide (http://elixir-lang.org/getting_started/mix_otp/9.html#9.2-pipelines), so it should probably support the current version.

Tests still pass under 1.0
