### PR TITLE
Add support for do/end blocks

### DIFF
--- a/lib/pipe.ex
+++ b/lib/pipe.ex
@@ -26,8 +26,11 @@ defmodule Pipe do
     do_pipe_matching(expr, test, pipes)
   end
 
+  defp unpipe([do: pipes]), do: Macro.unpipe(pipes)
+  defp unpipe(pipes), do: Macro.unpipe(pipes)
+
   defp do_pipe_matching(expr, test, pipes) do
-    [{h,_}|t] = Macro.unpipe(pipes)
+    [{h,_}|t] = unpipe(pipes)
     Enum.reduce t, h, &(reduce_matching &1, &2, expr, test)
   end
 
@@ -44,7 +47,7 @@ defmodule Pipe do
   #     json_doc |> transform |> transform
 
   defmacro pipe_while(test, pipes) do
-    [{h,_}|t] = Macro.unpipe(pipes)
+    [{h,_}|t] = unpipe(pipes)
     Enum.reduce t, h, &(reduce_if &1, &2, test)
   end
 
@@ -64,7 +67,7 @@ defmodule Pipe do
   #   [ 1, 2, 3] |> &(&1 + 1) |> &(&1 * 2)
 
   defmacro pipe_with(fun, pipes) do
-    [{h,_}|t] = Macro.unpipe(pipes)
+    [{h,_}|t] = unpipe(pipes)
     Enum.reduce t, h, &(reduce_with &1, &2, fun)
   end
 

--- a/test/pipes_test.exs
+++ b/test/pipes_test.exs
@@ -29,6 +29,11 @@ defmodule PipesTest do
     def ok_inc(x), do: {:ok, x + 1}
     def ok_double(x), do: {:ok, x * 2}
     def pipes, do: pipe_matching({:ok, _}, {:ok, 1} |> inc |> double )
+    def do_pipes do
+      pipe_matching {:ok, _} do
+        {:ok, 1} |> inc |> double
+      end
+    end
     def if_pipes, do: pipe_while(&if_test/1, {:ok, 1} |> inc |> double )
     def pipes_expr, do: pipe_matching(x, {:ok, x}, {:ok, 1} |> ok_inc |> ok_double )
   end
@@ -49,6 +54,10 @@ defmodule PipesTest do
   should "pipe matching" do
     assert  {:ok, 4} == Matching.pipes
     assert  {:ok, 4} == Matching.pipes_expr
+  end
+
+  should "pipe do" do
+    assert  {:ok, 4} == Matching.do_pipes
   end
 
   should "pipe if" do


### PR DESCRIPTION
It's now possible to express pipes like this, adapted from the Russian Roulette
example:

```elixir
iex> pipe_matching {:ok, _} do
...>   {:ok, ""}
...>   |> click
...>   |> click
...>   |> bang
...>   |> click
...> end
click...
click...
BANG.
{:error, "bang"}
```