### PR TITLE
Revert "pipe with error monade logic"

### DIFF
--- a/lib/pipe.ex
+++ b/lib/pipe.ex
@@ -74,20 +74,4 @@ defmodule Pipe do
       unquote(outer).(unquote(acc), fn(x) -> unquote(pipe) end)
     end
   end
-
-  # pipe with error-monad logic
-  defmacro pipe_error_m(pipes) do
-    [{h,_}|t] = Macro.unpipe(pipes)
-    Enum.reduce t, h, &(reduce_matching &1, &2)
-  end
-
-  defp reduce_matching({x, pos}, acc) do
-    quote do
-      case unquote(acc) do
-        {:ok, val} -> unquote(Macro.pipe((quote do: val), x, pos))
-        {:error, reason} -> {:error, reason}
-        val -> unquote(Macro.pipe((quote do: val), x, pos))
-      end
-    end
-  end
 end

--- a/test/pipes_test.exs
+++ b/test/pipes_test.exs
@@ -33,17 +33,6 @@ defmodule PipesTest do
     def pipes_expr, do: pipe_matching(x, {:ok, x}, {:ok, 1} |> ok_inc |> ok_double )
   end
 
-  defmodule ErrorM do
-    use Pipe
-    def inc(x), do: {:ok, x + 1}
-    def double(x), do: {:ok, x * 2}
-    def ok_inc(x), do: {:ok, x + 1}
-    def ok_double(x), do: {:ok, x * 2}
-    def pipes_error_m, do: pipe_error_m( 1 |> inc |> double )
-    def pipes_error_m_ok, do: pipe_error_m( 1 |> ok_inc |> ok_double )
-    def pipes_error_m_comb, do: pipe_error_m( 1 |> inc |> ok_inc |> double |> ok_double)
-  end
-
 
   should "compose with identity function" do
     assert [-2, 0, 2] == Simple.with_pipes_identity
@@ -64,11 +53,5 @@ defmodule PipesTest do
 
   should "pipe if" do
     assert  {:ok, 4} == Matching.if_pipes
-  end
-
-  should "pipe error_m" do
-    assert  {:ok, 4} == ErrorM.pipes_error_m
-    assert  {:ok, 4} == ErrorM.pipes_error_m_ok
-    assert  {:ok, 12} == ErrorM.pipes_error_m_comb
   end
 end


### PR DESCRIPTION
I'm sorry, but this PR isn't the best solution (.
it generate too much cases without the need, so dialyzer will tell us about it.
if we want to use this logic with pipes style, it's necessary to add more logic, may be some types check of accumulated code and generate only needed clause